### PR TITLE
Sugestão para solucionar o problema descrito no log da rinha

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,4 +1,5 @@
 import os
+import time
 import psycopg2
 import psycopg2.pool
 import contextlib
@@ -15,9 +16,32 @@ PG_POOL = int(os.getenv("PG_POOL") or 10)
 #                         password=PG_PASSWORD,
 #                         port=PG_PORT)
 
-Pool = psycopg2.pool.SimpleConnectionPool( 
-    PG_POOL/2, PG_POOL, user=PG_USER, password=PG_PASSWORD, 
-    host=PG_HOST, port=PG_PORT, database=PG_DB)
+# tenta reconectar até que o postgres esteja pronto para receber conexões
+Pool = None
+while not Pool:
+    try:
+        Pool = psycopg2.pool.SimpleConnectionPool( 
+            PG_POOL/2, PG_POOL, user=PG_USER, password=PG_PASSWORD, 
+            host=PG_HOST, port=PG_PORT, database=PG_DB)
+    except psycopg2.OperationalError as erro:
+        print(erro)
+        time.sleep(1)
+
+# outra solução possível seria checar se o postgres está pronto com healthcheck no seu docker-compose.yml
+# api01: &app
+#   [...] demais configurações
+#   depends_on:
+#     rinha-db:
+#       condition: service_healthy
+#
+# rinha-db:
+#   [...] demais configurações
+#   healthcheck:
+#     test: ["CMD-SHELL", "pg_isready"]
+#     interval: 5s
+#     timeout: 5s
+#     retries: 4
+# assim não seria preciso mexer no código, mas o docker ficará verificando o container do postgres constantemente de 5 em 5 segundos... o que consumirá processamento do container
 
 # Dependency
 @contextlib.contextmanager


### PR DESCRIPTION
Apenas uma sugestão de como tentar resolver o problema que aparece no [docker-compose.logs](https://github.com/zanfranceschi/rinha-de-backend-2024-q1/blob/main/participantes/welitonfreitas/docker-compose.logs) da [rinha de backend](https://github.com/zanfranceschi/rinha-de-backend-2024-q1).
Aparentemente a API tenta se conectar ao postgres antes que ele se encontre pronto para aceitar conexões, o que faz com que o uvicorn suba, mas a API não, causando um erro 502 BAD GATEWAY no nginx.